### PR TITLE
Update project to support SSR with Auth0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ testem.log
 .DS_Store
 Thumbs.db
 settings.json
+
+# Angular cache
+.angular

--- a/src/app/app.server.module.ts
+++ b/src/app/app.server.module.ts
@@ -4,7 +4,7 @@ import { ServerModule } from '@angular/platform-server';
 import { AppModule } from './app.module';
 import { AppComponent } from './app.component';
 import { AuthServerService } from './auth.server.service';
-import { AuthService } from '@auth0/auth0-angular';
+import { Auth0AuthService } from './services/auth.service';
 
 @NgModule({
   imports: [
@@ -12,7 +12,7 @@ import { AuthService } from '@auth0/auth0-angular';
     ServerModule,
   ],
   providers: [{
-    provide: AuthService,
+    provide: Auth0AuthService,
     useClass: AuthServerService,
   }],
   bootstrap: [AppComponent],

--- a/src/app/auth.server.service.ts
+++ b/src/app/auth.server.service.ts
@@ -1,12 +1,19 @@
 import { Injectable } from '@angular/core';
-import { AuthService } from '@auth0/auth0-angular';
-import { Observable, of } from 'rxjs';
+import { of } from 'rxjs';
+import { Auth0AuthService } from './services/auth.service';
 
 @Injectable()
-export class AuthServerService extends AuthService {
-  handleRedirectCallback(
-    url?: string
-  ): Observable<any> {
-    return of({});
+export class AuthServerService extends Auth0AuthService {
+
+  constructor() {
+    // Using `as any` here to avoid providing an implementation for all methods.
+    // In reality, you want to provide a full mock version instead and drop the `as any`.
+    super({
+      loginWithRedirect: () => of(),
+      logout: () => of(),
+      getAccessTokenSilently: () => of(),
+      isAuthenticated$: of(false),
+      user$: of(null)
+    } as any);
   }
 }


### PR DESCRIPTION
Updates the project to support SSR.

Because you have a service that wraps our Auth0 service, the easiest, in this case, would be to create a fake Server version of your Auth0 wrapper.

With those changes, I can successfully login:

![image](https://user-images.githubusercontent.com/2146903/167577563-0c6aa0fb-d289-4a72-8f11-305f3ac208f5.png)
